### PR TITLE
Profile image

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -10,6 +10,8 @@ use App\Models\Profile;
 use App\Models\VRACore\VRACContributorName;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Jcupitt\Vips\Image;
 
 class UserController extends Controller
 {
@@ -74,10 +76,58 @@ class UserController extends Controller
         if ($request->filled('password')) $user->password = Hash::make($request->input('password'));
 
         if ($request->hasFile('image')) {
-            if ($user->avatar_path) {
-                Storage::disk('public')->delete($user->avatar_path);
+            try {
+
+                if ($user->avatar_path) {
+                    Storage::disk('public')->delete($user->avatar_path);
+                }
+                // $user->avatar_path = $request->file('image')->store('profileImage', 'public');
+
+
+                $filename = 'profileImage/' . Str::uuid() . '.webp';
+                $destPath  = Storage::disk('public')->path($filename);
+                $uploadedFile = $request->file('image');
+
+                $image = Image::newFromBuffer(
+                    $uploadedFile->getContent(),
+                    '',
+                    ['access' => 'sequential']
+                );
+
+
+                $width  = $image->width;
+                $height = $image->height;
+
+                // crop centralizado para um quadrado
+                $minSide = min($width, $height);
+
+                $image = $image->crop(
+                    (int) (($width  - $minSide) / 2),   // left offset
+                    (int) (($height - $minSide) / 2),   // top offset
+                    $minSide,
+                    $minSide
+                );
+
+                // redimensiona para 400x400, forçando o tamanho (pode distorcer a imagem)
+                $image = $image->thumbnail_image(400, [
+                    'height' => 400,
+                    'size' => 'force',
+                ]);
+
+                $image->writeToFile($destPath, [
+                    'Q'             => 82,    // qualidade (0-100)
+                    'strip'         => true,  // remove EXIF/metadados
+                ]);
+
+                $user->avatar_path = $filename;
+            } catch (\Throwable $e) {
+                // Isso vai mostrar o erro real em vez do 500 genérico
+                return response()->json([
+                    'error'   => $e->getMessage(),
+                    'file'    => $e->getFile(),
+                    'line'    => $e->getLine(),
+                ], 500);
             }
-            $user->avatar_path = $request->file('image')->store('profileImage', 'public');
         }
 
         $user->save();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -76,58 +76,44 @@ class UserController extends Controller
         if ($request->filled('password')) $user->password = Hash::make($request->input('password'));
 
         if ($request->hasFile('image')) {
-            try {
 
-                if ($user->avatar_path) {
-                    Storage::disk('public')->delete($user->avatar_path);
-                }
-                // $user->avatar_path = $request->file('image')->store('profileImage', 'public');
-
-
-                $filename = 'profileImage/' . Str::uuid() . '.webp';
-                $destPath  = Storage::disk('public')->path($filename);
-                $uploadedFile = $request->file('image');
-
-                $image = Image::newFromBuffer(
-                    $uploadedFile->getContent(),
-                    '',
-                    ['access' => 'sequential']
-                );
-
-
-                $width  = $image->width;
-                $height = $image->height;
-
-                // crop centralizado para um quadrado
-                $minSide = min($width, $height);
-
-                $image = $image->crop(
-                    (int) (($width  - $minSide) / 2),   // left offset
-                    (int) (($height - $minSide) / 2),   // top offset
-                    $minSide,
-                    $minSide
-                );
-
-                // redimensiona para 400x400, forçando o tamanho (pode distorcer a imagem)
-                $image = $image->thumbnail_image(400, [
-                    'height' => 400,
-                    'size' => 'force',
-                ]);
-
-                $image->writeToFile($destPath, [
-                    'Q'             => 82,    // qualidade (0-100)
-                    'strip'         => true,  // remove EXIF/metadados
-                ]);
-
-                $user->avatar_path = $filename;
-            } catch (\Throwable $e) {
-                // Isso vai mostrar o erro real em vez do 500 genérico
-                return response()->json([
-                    'error'   => $e->getMessage(),
-                    'file'    => $e->getFile(),
-                    'line'    => $e->getLine(),
-                ], 500);
+            if ($user->avatar_path) {
+                Storage::disk('public')->delete($user->avatar_path);
             }
+
+            $filename = 'profileImage/' . Str::uuid() . '.webp';
+            $destPath  = Storage::disk('public')->path($filename);
+            $uploadedFile = $request->file('image');
+
+            $image = Image::newFromBuffer(
+                $uploadedFile->getContent(),
+                '',
+                ['access' => 'sequential']
+            );
+
+            $width  = $image->width;
+            $height = $image->height;
+
+            $minSide = min($width, $height);
+
+            $image = $image->crop(
+                (int) (($width  - $minSide) / 2),
+                (int) (($height - $minSide) / 2),
+                $minSide,
+                $minSide
+            );
+
+            $image = $image->thumbnail_image(400, [
+                'height' => 400,
+                'size' => 'force',
+            ]);
+
+            $image->writeToFile($destPath, [
+                'Q'             => 82,
+                'strip'         => true,
+            ]);
+
+            $user->avatar_path = $filename;
         }
 
         $user->save();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\User\UpdateUserRequest;
 use App\Models\Profile;
 use App\Models\VRACore\VRACContributorName;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
 
 class UserController extends Controller
 {
@@ -71,6 +72,14 @@ class UserController extends Controller
         $user->name = $request->input('name');
         if ($user->email != $request->input('email')) $user->email = $request->input('email');
         if ($request->filled('password')) $user->password = Hash::make($request->input('password'));
+
+        if ($request->hasFile('image')) {
+            if ($user->avatar_path) {
+                Storage::disk('public')->delete($user->avatar_path);
+            }
+            $user->avatar_path = $request->file('image')->store('profileImage', 'public');
+        }
+
         $user->save();
 
         return response()->json([
@@ -85,7 +94,7 @@ class UserController extends Controller
     {
         optional($user->profile())->delete();
         $user->delete();
-        
+
         return response()->json([
             'user' => $user,
         ]);

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -37,4 +37,14 @@ class UpdateUserRequest extends FormRequest
             'image' => ['nullable', 'image', 'mimes:jpg,jpeg,png', 'dimensions:max_width=2000,max_height=2000', 'max:5120']
         ];
     }
+
+    public function messages()
+    {
+        return [
+            'image.image' => 'O arquivo deve ser uma imagem válida.',
+            'image.mimes' => 'A imagem deve estar no formato: JPG, JPEG ou PNG.',
+            'image.dimensions' => 'A imagem deve ter no máximo 2000x2000 pixels.',
+            'image.max' => 'A imagem deve ter no máximo 5MB.',
+        ];
+    }
 }

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -34,6 +34,7 @@ class UpdateUserRequest extends FormRequest
                 Rule::unique('users')->ignore($this->user()->id),
             ],
             'password' => ['nullable', 'max:250', Password::min(8)],
+            'image' => ['nullable', 'image', 'mimes:jpg,jpeg,png', 'dimensions:max_width=2000,max_height=2000', 'max:5120']
         ];
     }
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -40,7 +40,7 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
+            'url' => env('APP_URL') . '/storage',
             'visibility' => 'public',
             'throw' => false,
         ],
@@ -72,6 +72,7 @@ return [
 
     'links' => [
         public_path('iiif') => storage_path('app/public/images/iiif'),
+        public_path('storage') => storage_path('app/public'),
     ],
 
 ];

--- a/lang/pt-BR/validation.php
+++ b/lang/pt-BR/validation.php
@@ -99,12 +99,6 @@ return [
         'attribute-name' => [
             'rule-name' => 'custom-message',
         ],
-        'image' => [
-            'image'      => 'O arquivo deve ser uma imagem válida.',
-            'mimes'      => 'A imagem deve estar no formato: JPG, JPEG ou PNG.',
-            'max'        => 'A imagem deve ter no máximo 5MB.',
-            'dimensions' => 'A imagem deve ter no máximo 2000x2000 pixels.',
-        ],
     ],
 
     /*

--- a/lang/pt-BR/validation.php
+++ b/lang/pt-BR/validation.php
@@ -99,6 +99,12 @@ return [
         'attribute-name' => [
             'rule-name' => 'custom-message',
         ],
+        'image' => [
+            'image'      => 'O arquivo deve ser uma imagem válida.',
+            'mimes'      => 'A imagem deve estar no formato: JPG, JPEG ou PNG.',
+            'max'        => 'A imagem deve ter no máximo 5MB.',
+            'dimensions' => 'A imagem deve ter no máximo 2000x2000 pixels.',
+        ],
     ],
 
     /*


### PR DESCRIPTION
## Upload e processamento de imagem de perfil com libvips

### O que foi feito
- Implementação da funcionalidade de upload basica com salvamento no banco  de dados com `Store`
- Integração da biblioteca **libvips** (`jcupitt/vips`) para processamento de imagens
- Implementação do upload de avatar com crop central e conversão para **WebP**
- Adição de validação de imagem no `UpdateUserRequest` (tamanho máximo 5MB, dimensões e formatos aceitos)
- Tradução das mensagens de validação para pt-BR

### Detalhes técnicos
- Uso de `newFromBuffer` + `writeToBuffer` para evitar problemas de stack com FFI

### Visualização do teste
<img width="1112" height="345" alt="image" src="https://github.com/user-attachments/assets/2eef6b24-3513-48b3-a3f7-81b013510d02" />

---

## Curiosidade: Como é trabalhado o redimensionamento

No backend, a imagem recebida passa por três operações distintas usando `libvips`: recorte, redimensionamento e exportação com compressão.

O recorte transforma a imagem em um quadrado. O código pega o menor lado da imagem original e usa esse valor como tamanho do quadrado. As coordenadas de início do recorte são calculadas subtraindo o menor lado de cada dimensão e dividindo por dois, o que centraliza o recorte. Uma imagem de 1200×800 por exemplo teria um quadrado de 800×800 recortado do centro horizontal.

Após o recorte, `thumbnail_image` redimensiona o quadrado resultante para exatamente 400×400 pixels. O parâmetro `size: force` faz com que as dimensões sejam forçadas sem respeitar proporção, mas como a imagem já é quadrada nesse ponto, não há distorção.

Na exportação, `writeToFile` converte e salva o arquivo em formato `WebP` com qualidade `Q: 82`. Esse número representa o nível de compressão do `codec WebP`, onde valores mais baixos produzem arquivos menores com mais perda de qualidade. 82 é um valor conservador que mantém boa fidelidade visual com redução significativa de tamanho. A flag `strip: true` remove os metadados embutidos na imagem, como dados EXIF, o que contribui adicionalmente para a redução do tamanho final do arquivo.

Em resumo, dois redimensionamentos são feitos em sequência.
O primeiro transforma a imagem em um quadrado. O código identifica o menor lado da imagem original e usa esse valor para recortar uma área centralizada. Uma imagem de 1200×800 vira 800×800, recortada do centro.
O segundo reduz esse quadrado para 400×400 pixels usando thumbnail_image com size: force, que força as duas dimensões exatas sem respeitar proporção. Como a imagem já é quadrada nesse ponto, não há distorção.

