### PR TITLE
feat: add polymorphic reports system for images

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Report;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+
+class ReportController extends Controller
+{
+    protected array $morphMap = [
+        'image' => \App\Models\VRACore\VRACImage::class,
+    ];
+
+    /**
+     * Criar denúncia
+     *
+     * @group Reports
+     * @authenticated
+     *
+     * @bodyParam reportable_type string required Tipo do conteúdo denunciado. Valores aceitos: `image`. Example: image
+     * @bodyParam reportable_id string required UUID do conteúdo denunciado. Example: 940d841b-2c1e-4652-b7a9-0d0113cfa083
+     * @bodyParam reason string required Motivo da denúncia. Valores aceitos: `copyright`, `inappropriate`, `spam`, `harassment`, `misinformation`, `other`. Example: spam
+     * @bodyParam description string Descrição opcional com mais detalhes. Example: Esta imagen parece ser contenido duplicado.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'reportable_type' => ['required', 'string', Rule::in(array_keys($this->morphMap))],
+            'reportable_id'   => ['required', 'string'],
+            'reason'          => ['required', Rule::in([
+                'copyright', 'inappropriate', 'spam', 'harassment', 'misinformation', 'other',
+            ])],
+            'description'     => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $modelClass = $this->morphMap[$request->reportable_type];
+        $reportable = $modelClass::findOrFail($request->reportable_id);
+
+        // No puede denunciar su propio contenido
+        if (isset($reportable->user_id) && $reportable->user_id === $request->user()->id) {
+            return response()->json([
+                'message' => 'No puedes denunciar tu propio contenido.',
+            ], 422);
+        }
+
+        // No puede denunciar el mismo contenido dos veces
+        $alreadyReported = Report::where('reporter_id', $request->user()->id)
+            ->where('reportable_type', $modelClass)
+            ->where('reportable_id', $reportable->id)
+            ->exists();
+
+        if ($alreadyReported) {
+            return response()->json([
+                'message' => 'Ya has denunciado este contenido.',
+            ], 422);
+        }
+
+        $report = new Report();
+        $report->id = (string) Str::uuid();
+        $report->reportable_type = $modelClass;
+        $report->reportable_id = $reportable->id;
+        $report->reporter_id = $request->user()->id;
+        $report->reason = $request->reason;
+        $report->description = $request->description;
+        $report->status = 'pending';
+        $report->save();
+
+        return response()->json([
+            'message' => 'Denuncia enviada correctamente.',
+            'report'  => $report,
+        ], 201);
+    }
+
+    /**
+     * Buscar denúncia por ID
+     *
+     * @group Reports
+     * @authenticated
+     */
+    public function show(Report $report)
+    {
+        $report->load(['reportable', 'reporter']);
+
+        return response()->json([
+            'report' => $report,
+        ]);
+    }
+
+    /**
+     * Listar denúncias
+     *
+     * @group Reports
+     * @authenticated
+     *
+     * @queryParam status string Filtrar por estado. Valores aceitos: `pending`, `reviewed`, `resolved`, `dismissed`. Example: pending
+     * @queryParam reportable_type string Filtrar por tipo de conteúdo. Valores aceitos: `image`. Example: image
+     */
+    public function index(Request $request)
+    {
+        $query = Report::with(['reportable', 'reporter'])
+            ->latest();
+
+        if ($request->filled('status')) {
+            $query->where('status', $request->status);
+        }
+
+        if ($request->filled('reportable_type') && isset($this->morphMap[$request->reportable_type])) {
+            $query->where('reportable_type', $this->morphMap[$request->reportable_type]);
+        }
+
+        return response()->json([
+            'reports' => $query->paginate(20),
+        ]);
+    }
+
+    /**
+     * Atualizar status de denúncia
+     *
+     * @group Reports
+     * @authenticated
+     *
+     * @bodyParam status string required Novo status da denúncia. Valores aceitos: `reviewed`, `resolved`, `dismissed`. Example: resolved
+     */
+    public function update(Request $request, Report $report)
+    {
+        $request->validate([
+            'status' => ['required', Rule::in(['reviewed', 'resolved', 'dismissed'])],
+        ]);
+
+        $report->status = $request->status;
+        $report->save();
+
+        return response()->json([
+            'message' => 'Denuncia actualizada.',
+            'report'  => $report,
+        ]);
+    }
+}

--- a/app/Models/Report.php
+++ b/app/Models/Report.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Report extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'reportable_type',
+        'reportable_id',
+        'reporter_id',
+        'reason',
+        'description',
+        'status',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'id'              => 'string',
+            'reportable_id'   => 'string',
+            'reporter_id'     => 'string',
+            'reason'          => 'string',
+            'description'     => 'string',
+            'status'          => 'string',
+        ];
+    }
+
+    public function reportable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function reporter(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reporter_id');
+    }
+}

--- a/app/Models/VRACore/VRACImage.php
+++ b/app/Models/VRACore/VRACImage.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use App\Models\Report;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class VRACImage extends Model
@@ -197,5 +199,10 @@ class VRACImage extends Model
     public function locations(): BelongsToMany
     {
         return $this->belongsToMany(Location::class, 'image_location', 'image_id', 'location_id');
+    }
+
+    public function reports(): MorphMany
+    {
+        return $this->morphMany(Report::class, 'reportable');
     }
 }

--- a/database/migrations/2026_05_04_000001_create_reports_table.php
+++ b/database/migrations/2026_05_04_000001_create_reports_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('reports', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuidMorphs('reportable');
+            $table->foreignUuid('reporter_id')->constrained('users')->cascadeOnDelete();
+            $table->enum('reason', [
+                'copyright',
+                'inappropriate',
+                'spam',
+                'harassment',
+                'misinformation',
+                'other',
+            ]);
+            $table->text('description')->nullable();
+            $table->enum('status', ['pending', 'reviewed', 'resolved', 'dismissed'])
+                ->default('pending');
+            $table->timestamps();
+
+            $table->unique(['reporter_id', 'reportable_type', 'reportable_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reports');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,6 +32,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AlbumController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\CommentLikeController;
+use App\Http\Controllers\ReportController;
 
 // álbumes
 Route::get('/albums', [AlbumController::class, 'index']);
@@ -93,6 +94,12 @@ Route::middleware('auth:api')->group(function () {
     Route::put('/albums/{album}/images', [AlbumController::class, 'syncImages']);
     Route::post('/albums/{album}/images', [AlbumController::class, 'addImage']);
     Route::delete('/albums/{album}/images', [AlbumController::class, 'removeImages']);
+
+    // Reports
+    Route::post('/reports', [ReportController::class, 'store']);
+    Route::get('/reports', [ReportController::class, 'index']);
+    Route::get('/reports/{report}', [ReportController::class, 'show']);
+    Route::patch('/reports/{report}', [ReportController::class, 'update']);
 
     //suggestions
     Route::post('/images/{image}/suggestions', [ImageSuggestionController::class, 'store']);


### PR DESCRIPTION
## Descrição

Implementação do sistema de denúncias com design polimórfico, permitindo que usuários autenticados denunciem conteúdos da plataforma.


- Criada tabela `reports` com suporte polimórfico (`reportable_type` + `reportable_id`)
- Modelo `Report` com relações `morphTo` (conteúdo denunciado) e `belongsTo` (usuário denunciante)
- Relação `reports()` adicionada ao modelo `VRACImage`
- Endpoints implementados:
  - `POST /api/reports` — criar denúncia
  - `GET /api/reports` — listar denúncias (futuro admin)
  - `GET /api/reports/{id}` — buscar denúncia por ID
  - `PATCH /api/reports/{report}` — atualizar status da denúncia

## Validações

- Usuário não pode denunciar seu próprio conteúdo
- Usuário não pode denunciar o mesmo conteúdo duas vezes
- Motivos disponíveis: `copyright`, `inappropriate`, `spam`, `harassment`, `misinformation`, `other`
- Status disponíveis: `pending`, `reviewed`, `resolved`, `dismissed`

## Extensibilidade

O design polimórfico permite adicionar novos tipos de conteúdo denunciável (álbuns, perfis, coletivos) sem alterações na tabela ou no modelo — basta adicionar a entrada no `morphMap` do controlador.

## Observações

- Lógica de admin (restrição de acesso aos endpoints de listagem e atualização) será implementada quando o sistema de roles estiver disponível.