### PR TITLE
feat: add tags endpoint for albums

### DIFF
--- a/app/Http/Controllers/AlbumController.php
+++ b/app/Http/Controllers/AlbumController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Album;
+use App\Models\VRACore\VRACSubject;
 use Illuminate\Http\Request;
 
 /**
@@ -171,6 +172,30 @@ class AlbumController extends Controller
             ->where('user_id', $userId)
             ->get();
     }
+    /**
+     * Tags de um álbum
+     *
+     * Retorna todas as tags únicas das imagens do álbum.
+     *
+     * @group Álbuns
+     * @unauthenticated
+     */
+    public function tags(Album $album)
+    {
+        $tags = VRACSubject::select('vrac_subjects.id', 'vrac_subjects.term', 'vrac_subjects.type')
+            ->join('image_subject', 'vrac_subjects.id', '=', 'image_subject.subject_id')
+            ->join('album_image', 'image_subject.image_id', '=', 'album_image.image_id')
+            ->where('album_image.album_id', $album->id)
+            ->distinct()
+            ->orderBy('vrac_subjects.term')
+            ->get();
+
+        return response()->json([
+            'album_id' => $album->id,
+            'tags'     => $tags,
+        ]);
+    }
+
     public function syncImages(Request $request, $albumId)
     {
         $data = $request->validate([

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,6 +56,7 @@ Route::get('/comments/{commentId}/replies', [CommentController::class, 'replies'
 // álbumes
 Route::get('/albums', [AlbumController::class, 'index']);
 Route::get('/albums/{album}', [AlbumController::class, 'show']);
+Route::get('/albums/{album}/tags', [AlbumController::class, 'tags']);
 Route::get('/users/{user}/albums', [AlbumController::class, 'getByUser']);
 
 //suggestions


### PR DESCRIPTION
## Descrição

Adição de endpoint para retornar as tags únicas de um álbum.

## O que foi feito

- Novo endpoint `GET /api/albums/{album}/tags`
- Retorna todas as tags (subjects) únicas das imagens do álbum, sem repetição
- Resultado ordenado alfabeticamente pelo nome da tag
- Endpoint público, não requer autenticação

## Detalhes técnicos

A query percorre o caminho: `album_image` → `vrac_images` → `image_subject` → `vrac_subjects`, retornando apenas registros distintos em uma única consulta ao banco.