### PR TITLE
feat: allow collectives to create and manage albums

### DIFF
--- a/app/Http/Controllers/AlbumController.php
+++ b/app/Http/Controllers/AlbumController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Album;
+use App\Models\Collective;
 use App\Models\VRACore\VRACSubject;
 use Illuminate\Http\Request;
 
@@ -26,19 +27,28 @@ class AlbumController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'title' => 'nullable|string|max:255',
-            'description' => 'nullable|string|max:1000',
-            'is_private' => 'boolean'
+            'collective_id' => 'nullable|uuid|exists:collectives,id',
+            'title'         => 'nullable|string|max:255',
+            'description'   => 'nullable|string|max:1000',
+            'is_private'    => 'boolean',
         ]);
 
-        // Usuario autenticado
-        $data['user_id'] = $request->user()->id;
+        if (!empty($data['collective_id'])) {
+            $collective = Collective::findOrFail($data['collective_id']);
+            if (!$collective->isMember($request->user())) {
+                return response()->json([
+                    'message' => 'No eres miembro de este colectivo.',
+                ], 403);
+            }
+        } else {
+            $data['user_id'] = $request->user()->id;
+        }
 
         $album = Album::create($data);
 
         return response()->json([
             'message' => 'Álbum creado correctamente',
-            'album' => $album,
+            'album'   => $album,
         ], 201);
     }
 
@@ -56,33 +66,39 @@ class AlbumController extends Controller
     {
         $album = Album::findOrFail($id);
 
+        if (!$album->userCanManage($request->user())) {
+            return response()->json(['message' => 'No tienes permiso para editar este álbum.'], 403);
+        }
+
         $data = $request->validate([
-            'title' => 'sometimes|nullable|string|max:255',
+            'title'       => 'sometimes|nullable|string|max:255',
             'description' => 'sometimes|nullable|string|max:1000',
-            'is_private' => 'sometimes|boolean'
+            'is_private'  => 'sometimes|boolean',
         ]);
-            // evitar updates vacíos
-    if (empty($data)) {
-        return response()->json([
-            'message' => 'No se enviaron datos para actualizar'
-        ], 422);
-    }
+
+        if (empty($data)) {
+            return response()->json(['message' => 'No se enviaron datos para actualizar'], 422);
+        }
+
         $album->update($data);
 
         return response()->json([
             'message' => 'Álbum actualizado correctamente',
-            'album' => $album,
+            'album'   => $album,
         ], 200);
     }
 
     public function destroy($id)
     {
         $album = Album::findOrFail($id);
-        $album->delete(); // activa deleted_at
 
-        return response()->json([
-            'message' => 'Álbum eliminado (soft delete)'
-        ], 200);
+        if (!$album->userCanManage(request()->user())) {
+            return response()->json(['message' => 'No tienes permiso para eliminar este álbum.'], 403);
+        }
+
+        $album->delete();
+
+        return response()->json(['message' => 'Álbum eliminado (soft delete)'], 200);
     }
     public function addImage(Request $request, $albumId)
     {
@@ -93,6 +109,10 @@ class AlbumController extends Controller
         ]);
 
         $album = Album::findOrFail($albumId);
+
+        if (!$album->userCanManage($request->user())) {
+            return response()->json(['message' => 'No tienes permiso para agregar imágenes a este álbum.'], 403);
+        }
 
         // IDs ya existentes en el álbum (evita queries dentro del loop)
         $existingImages = $album->images()->pluck('image_id')->toArray();
@@ -141,8 +161,11 @@ class AlbumController extends Controller
             'image_ids.*' => 'required|uuid|exists:vrac_images,id',
         ]);
 
-        //$album = Album::where('user_id', auth()->id())->findOrFail($albumId);
-        $album = Album::where('user_id', $request->user()->id)->findOrFail($albumId);
+        $album = Album::findOrFail($albumId);
+
+        if (!$album->userCanManage($request->user())) {
+            return response()->json(['message' => 'No tienes permiso para eliminar imágenes de este álbum.'], 403);
+        }
         $existingImageIds = $album->images()
             ->wherePivotIn('image_id', $data['image_ids'])
             ->pluck('vrac_images.id')
@@ -172,6 +195,18 @@ class AlbumController extends Controller
             ->where('user_id', $userId)
             ->get();
     }
+    /**
+     * @unauthenticated
+     */
+    public function getByCollective($collectiveId)
+    {
+        return Album::with(['images' => function ($q) {
+            $q->orderBy('pivot_position');
+        }])
+            ->where('collective_id', $collectiveId)
+            ->get();
+    }
+
     /**
      * Tags de um álbum
      *
@@ -205,6 +240,10 @@ class AlbumController extends Controller
         ]);
 
         $album = Album::findOrFail($albumId);
+
+        if (!$album->userCanManage($request->user())) {
+            return response()->json(['message' => 'No tienes permiso para modificar las imágenes de este álbum.'], 403);
+        }
 
         //Construir array para sync
         $syncData = collect($data['images'])->mapWithKeys(function ($item) {

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -17,6 +17,7 @@ class Album extends Model
     protected $fillable = [
         'id',
         'user_id',
+        'collective_id',
         'title',
         'description',
         'is_private',
@@ -25,18 +26,43 @@ class Album extends Model
     protected function casts(): array
     {
         return [
-            'id' => 'string',
-            'user_id' => 'string',
-            'title' => 'string',
-            'description' => 'string',
-            'is_private' => 'boolean',
-            'deleted_at' => 'datetime',
+            'id'           => 'string',
+            'user_id'      => 'string',
+            'collective_id'=> 'string',
+            'title'        => 'string',
+            'description'  => 'string',
+            'is_private'   => 'boolean',
+            'deleted_at'   => 'datetime',
         ];
     }
 
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function collective(): BelongsTo
+    {
+        return $this->belongsTo(Collective::class);
+    }
+
+    public function isOwnedByUser(User $user): bool
+    {
+        return $this->user_id === $user->id;
+    }
+
+    public function isOwnedByCollective(): bool
+    {
+        return !is_null($this->collective_id);
+    }
+
+    public function userCanManage(User $user): bool
+    {
+        if ($this->isOwnedByCollective()) {
+            return $this->collective->isMember($user);
+        }
+
+        return $this->isOwnedByUser($user);
     }
 
     public function images(): BelongsToMany

--- a/database/migrations/2026_05_18_000001_add_collective_id_to_albums_table.php
+++ b/database/migrations/2026_05_18_000001_add_collective_id_to_albums_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('albums', function (Blueprint $table) {
+            $table->foreignUuid('collective_id')
+                ->nullable()
+                ->after('user_id')
+                ->constrained('collectives')
+                ->cascadeOnDelete();
+
+            $table->uuid('user_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('albums', function (Blueprint $table) {
+            $table->dropForeign(['collective_id']);
+            $table->dropColumn('collective_id');
+            $table->uuid('user_id')->nullable(false)->change();
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,6 +39,7 @@ use App\Http\Controllers\ReportController;
 Route::get('/albums', [AlbumController::class, 'index']);
 Route::get('/albums/{album}', [AlbumController::class, 'show']);
 Route::get('/users/{user}/albums', [AlbumController::class, 'getByUser']);
+Route::get('/collectives/{collectiveId}/albums', [AlbumController::class, 'getByCollective']);
 
 use App\Http\Controllers\ImageSuggestionController;
 


### PR DESCRIPTION
O que foi feito
Adicionado suporte para que coletivos possam criar e gerenciar álbuns de imagens.
Mudanças no backend
Migration

Adicionada coluna collective_id (nullable FK) na tabela albums
user_id passou a ser nullable para suportar álbuns de coletivos

Model Album

Adicionada relação collective()
Adicionado método userCanManage() que centraliza a lógica de permissão para álbuns de usuário e de coletivo

Controller AlbumController

store: aceita collective_id opcional, verifica se o usuário é membro do coletivo
update, destroy, addImage, removeImages, syncImages: todos usam userCanManage() para validar permissão
Novo método getByCollective($collectiveId)

Rotas novas

GET /api/collectives/{collectiveId}/albums — lista álbuns de um coletivo (público)