### PR TITLE
Feat/binomial evaluation

### DIFF
--- a/app/Console/Commands/ImportBinomialEvaluations.php
+++ b/app/Console/Commands/ImportBinomialEvaluations.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\BinomialEvaluation;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class ImportBinomialEvaluations extends Command
+{
+    protected $signature = 'binomials:import {file : Ruta al archivo CSV}';
+
+    protected $description = 'Importa evaluaciones de binomios desde un CSV del sistema legado';
+
+    // Mapping de binomial_id viejo → nuevo
+    private array $binomialMap = [
+        21 => 1, // Aberta / Fechada
+        20 => 2, // Interna / Externa
+        19 => 3, // Complexa / Simples
+        16 => 4, // Simétrica / Assimétrica
+        14 => 5, // Translúcida / Opaca
+        13 => 6, // Horizontal / Vertical
+    ];
+
+    public function handle(): int
+    {
+        $file = $this->argument('file');
+
+        if (! file_exists($file)) {
+            $this->error("Archivo no encontrado: {$file}");
+            return Command::FAILURE;
+        }
+
+        $this->info("Iniciando importación desde: {$file}");
+
+        // Pre-cargar mapeos en memoria para mayor velocidad
+        $this->info('Cargando mapeo de imágenes...');
+        $imageMap = DB::table('vrac_images')
+            ->whereNotNull('legacy_id')
+            ->pluck('id', 'legacy_id');
+
+        $this->info('Cargando mapeo de usuarios...');
+        $userMap = DB::table('users')
+            ->whereNotNull('legacy_id')
+            ->pluck('id', 'legacy_id');
+
+        $this->info("Imágenes mapeadas: {$imageMap->count()} | Usuarios mapeados: {$userMap->count()}");
+        $this->newLine();
+
+        $handle = fopen($file, 'r');
+        fgetcsv($handle); // saltar header
+
+        $imported        = 0;
+        $skippedNoImage  = 0;
+        $skippedNoUser   = 0;
+        $skippedBinomial = 0;
+        $total           = 0;
+
+        $bar = $this->output->createProgressBar();
+        $bar->start();
+
+        while (($row = fgetcsv($handle)) !== false) {
+            $total++;
+            [$id, $photoId, $evaluationPosition, $binomialId, $userId] = $row;
+
+            // Mapear binomial
+            if (! isset($this->binomialMap[(int) $binomialId])) {
+                $skippedBinomial++;
+                $bar->advance();
+                continue;
+            }
+
+            // Mapear imagen
+            if (! isset($imageMap[(int) $photoId])) {
+                $skippedNoImage++;
+                $bar->advance();
+                continue;
+            }
+
+            // Mapear usuario
+            if (! isset($userMap[(int) $userId])) {
+                $skippedNoUser++;
+                $bar->advance();
+                continue;
+            }
+
+            BinomialEvaluation::updateOrCreate(
+                [
+                    'image_id'    => $imageMap[(int) $photoId],
+                    'user_id'     => $userMap[(int) $userId],
+                    'binomial_id' => $this->binomialMap[(int) $binomialId],
+                ],
+                [
+                    'value' => (int) $evaluationPosition,
+                ]
+            );
+
+            $imported++;
+            $bar->advance();
+        }
+
+        fclose($handle);
+        $bar->finish();
+        $this->newLine(2);
+
+        $this->info('══════════════════════════════════════');
+        $this->info("Total filas procesadas : {$total}");
+        $this->info("Importadas             : {$imported}");
+        $this->warn("Skipeadas (sin imagen) : {$skippedNoImage}");
+        $this->warn("Skipeadas (sin usuario): {$skippedNoUser}");
+        $this->warn("Skipeadas (sin binomio): {$skippedBinomial}");
+        $this->info('══════════════════════════════════════');
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/BinomialEvaluationController.php
+++ b/app/Http/Controllers/BinomialEvaluationController.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Binomial\StoreBinomialEvaluationRequest;
+use App\Models\Binomial;
+use App\Models\BinomialEvaluation;
+use App\Models\VRACore\VRACImage;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class BinomialEvaluationController extends Controller
+{
+    /**
+     * Promedio general de binomios
+     *
+     * Retorna os binômios com o valor médio de todas as avaliações da imagem.
+     * Se o usuário estiver autenticado, inclui sua própria avaliação em `my_value`.
+     * Se não houver avaliações, retorna `data: null`.
+     *
+     * @group Binomials
+     * @unauthenticated
+     *
+     * @urlParam image string required UUID da imagem. Example: 000f9800-5186-4ebf-8f19-8e324749b846
+     */
+    public function index(Request $request, VRACImage $image): JsonResponse
+    {
+        $userId = $request->user()?->id;
+
+        $binomials = Binomial::where('active', true)
+            ->orderBy('order')
+            ->get();
+
+        $totalEvaluators = BinomialEvaluation::where('image_id', $image->id)
+            ->distinct('user_id')
+            ->count('user_id');
+
+        if ($totalEvaluators === 0) {
+            return response()->json([
+                'data'              => null,
+                'total_evaluators'  => 0,
+            ]);
+        }
+
+        // Averages por binomio
+        $averages = BinomialEvaluation::where('image_id', $image->id)
+            ->selectRaw('binomial_id, ROUND(AVG(value), 1) as average')
+            ->groupBy('binomial_id')
+            ->pluck('average', 'binomial_id')
+            ->map(fn ($avg) => (float) $avg);
+
+        // Evaluación propia del usuario
+        $myValues = [];
+        if ($userId) {
+            $myValues = BinomialEvaluation::where('image_id', $image->id)
+                ->where('user_id', $userId)
+                ->pluck('value', 'binomial_id')
+                ->toArray();
+        }
+
+        $data = $binomials->map(fn ($b) => [
+            'id'         => $b->id,
+            'word_left'  => $b->word_left,
+            'word_right' => $b->word_right,
+            'order'      => $b->order,
+            'average'    => $averages[$b->id] ?? null,
+            'my_value'   => $myValues[$b->id] ?? null,
+        ]);
+
+        return response()->json([
+            'data'             => $data,
+            'total_evaluators' => $totalEvaluators,
+        ]);
+    }
+
+    /**
+     * Enviar avaliação de binômios
+     *
+     * Cria ou atualiza a avaliação do usuário autenticado para a imagem.
+     * Deve enviar todos os binômios em um único envio. Se o usuário já avaliou, os valores são atualizados.
+     *
+     * @group Binomials
+     * @authenticated
+     *
+     * @urlParam image string required UUID da imagem. Example: 000f9800-5186-4ebf-8f19-8e324749b846
+     * @bodyParam evaluations array required Lista de avaliações, uma por binômio.
+     * @bodyParam evaluations[].binomial_id integer required ID do binômio. Example: 1
+     * @bodyParam evaluations[].value integer required Valor entre 0 e 100. Example: 75
+     */
+    public function store(StoreBinomialEvaluationRequest $request, VRACImage $image): JsonResponse
+    {
+        $userId  = $request->user()->id;
+        $created = false;
+        $updated = false;
+
+        foreach ($request->evaluations as $evaluation) {
+            $record = BinomialEvaluation::updateOrCreate(
+                [
+                    'image_id'    => $image->id,
+                    'user_id'     => $userId,
+                    'binomial_id' => $evaluation['binomial_id'],
+                ],
+                [
+                    'value' => $evaluation['value'],
+                ]
+            );
+
+            $record->wasRecentlyCreated ? $created = true : $updated = true;
+        }
+
+        $message = match (true) {
+            $created && !$updated => 'Evaluación guardada correctamente.',
+            !$created && $updated => 'Evaluación actualizada correctamente.',
+            default               => 'Evaluación guardada y actualizada correctamente.',
+        };
+
+        $myEvaluations = BinomialEvaluation::where('image_id', $image->id)
+            ->where('user_id', $userId)
+            ->with('binomial')
+            ->get()
+            ->map(fn ($e) => [
+                'binomial_id' => $e->binomial_id,
+                'word_left'   => $e->binomial->word_left,
+                'word_right'  => $e->binomial->word_right,
+                'order'       => $e->binomial->order,
+                'value'       => $e->value,
+            ])
+            ->sortBy('order')
+            ->values();
+
+        return response()->json([
+            'message' => $message,
+            'data'    => $myEvaluations,
+        ]);
+    }
+
+    /**
+     * Relatório de médias por data
+     *
+     * Retorna a média das avaliações de binômios da imagem com filtros opcionais de ano e mês.
+     * Se não houver avaliações no período, retorna `data: null`.
+     *
+     * @group Binomials
+     * @unauthenticated
+     *
+     * @urlParam image string required UUID da imagem. Example: 000f9800-5186-4ebf-8f19-8e324749b846
+     * @queryParam year integer Filtrar por ano. Example: 2026
+     * @queryParam month integer Filtrar por mês (1-12). Example: 5
+     */
+    public function report(Request $request, VRACImage $image): JsonResponse
+    {
+        $request->validate([
+            'year'  => ['nullable', 'integer', 'min:2000', 'max:2100'],
+            'month' => ['nullable', 'integer', 'min:1', 'max:12'],
+        ]);
+
+        $binomials = Binomial::where('active', true)->orderBy('order')->get();
+        $query     = $this->applyDateFilters(
+            BinomialEvaluation::where('image_id', $image->id),
+            $request
+        );
+
+        $totalEvaluators = (clone $query)->distinct('user_id')->count('user_id');
+        $filters = [
+            'year'  => $request->filled('year') ? (int) $request->year : null,
+            'month' => $request->filled('month') ? (int) $request->month : null,
+        ];
+
+        if ($totalEvaluators === 0) {
+            return response()->json([
+                'data'             => null,
+                'total_evaluators' => 0,
+                'filters'          => $filters,
+            ]);
+        }
+
+        $averages = (clone $query)
+            ->selectRaw('binomial_id, ROUND(AVG(value), 1) as average')
+            ->groupBy('binomial_id')
+            ->pluck('average', 'binomial_id')
+            ->map(fn ($avg) => (float) $avg);
+
+        $data = $binomials->map(fn ($b) => [
+            'id'         => $b->id,
+            'word_left'  => $b->word_left,
+            'word_right' => $b->word_right,
+            'order'      => $b->order,
+            'average'    => $averages[$b->id] ?? null,
+        ]);
+
+        return response()->json([
+            'data'             => $data,
+            'total_evaluators' => $totalEvaluators,
+            'filters'          => $filters,
+        ]);
+    }
+
+    /**
+     * Relatório de avaliações individuais
+     *
+     * Retorna todas as avaliações individuais da imagem de forma anonimizada, junto com as médias por binômio.
+     * Suporta filtros opcionais de ano e mês. Cada item em `evaluations` representa um avaliador (linha do gráfico).
+     * Se não houver avaliações no período, retorna `evaluations: []`.
+     *
+     * @group Binomials
+     * @unauthenticated
+     *
+     * @urlParam image string required UUID da imagem. Example: 000f9800-5186-4ebf-8f19-8e324749b846
+     * @queryParam year integer Filtrar por ano. Example: 2026
+     * @queryParam month integer Filtrar por mês (1-12). Example: 5
+     */
+    public function evaluations(Request $request, VRACImage $image): JsonResponse
+    {
+        $request->validate([
+            'year'  => ['nullable', 'integer', 'min:2000', 'max:2100'],
+            'month' => ['nullable', 'integer', 'min:1', 'max:12'],
+        ]);
+
+        $binomials = Binomial::where('active', true)->orderBy('order')->get();
+        $query     = $this->applyDateFilters(
+            BinomialEvaluation::where('image_id', $image->id),
+            $request
+        );
+
+        $totalEvaluators = (clone $query)->distinct('user_id')->count('user_id');
+        $filters = [
+            'year'  => $request->filled('year') ? (int) $request->year : null,
+            'month' => $request->filled('month') ? (int) $request->month : null,
+        ];
+
+        if ($totalEvaluators === 0) {
+            return response()->json([
+                'binomials'        => $binomials->map(fn ($b) => [
+                    'id'         => $b->id,
+                    'word_left'  => $b->word_left,
+                    'word_right' => $b->word_right,
+                    'order'      => $b->order,
+                ]),
+                'evaluations'      => [],
+                'averages'         => null,
+                'total_evaluators' => 0,
+                'filters'          => $filters,
+            ]);
+        }
+
+        // Agrupar evaluaciones por usuario (anonimizado)
+        $rawEvaluations = (clone $query)->get();
+
+        $evaluations = $rawEvaluations
+            ->groupBy('user_id')
+            ->map(fn ($userEvals) => [
+                'values' => $userEvals->pluck('value', 'binomial_id'),
+            ])
+            ->values();
+
+        // Promedios
+        $averages = (clone $query)
+            ->selectRaw('binomial_id, ROUND(AVG(value), 1) as average')
+            ->groupBy('binomial_id')
+            ->pluck('average', 'binomial_id')
+            ->map(fn ($avg) => (float) $avg);
+
+        return response()->json([
+            'binomials' => $binomials->map(fn ($b) => [
+                'id'         => $b->id,
+                'word_left'  => $b->word_left,
+                'word_right' => $b->word_right,
+                'order'      => $b->order,
+            ]),
+            'evaluations'      => $evaluations,
+            'averages'         => $averages,
+            'total_evaluators' => $totalEvaluators,
+            'filters'          => $filters,
+        ]);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────
+
+    private function applyDateFilters($query, Request $request)
+    {
+        if ($request->filled('year')) {
+            $query->whereYear('created_at', $request->year);
+        }
+
+        if ($request->filled('month')) {
+            $query->whereMonth('created_at', $request->month);
+        }
+
+        return $query;
+    }
+}

--- a/app/Http/Requests/Binomial/StoreBinomialEvaluationRequest.php
+++ b/app/Http/Requests/Binomial/StoreBinomialEvaluationRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Binomial;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreBinomialEvaluationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'evaluations'               => ['required', 'array', 'min:1'],
+            'evaluations.*.binomial_id' => ['required', 'integer', 'exists:binomials,id'],
+            'evaluations.*.value'       => ['required', 'integer', 'min:0', 'max:100'],
+        ];
+    }
+}

--- a/app/Models/Binomial.php
+++ b/app/Models/Binomial.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Binomial extends Model
+{
+    protected $fillable = [
+        'word_left',
+        'word_right',
+        'order',
+        'active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'order'  => 'integer',
+            'active' => 'boolean',
+        ];
+    }
+
+    // ─── Relationships ────────────────────────────────────────────
+
+    public function evaluations(): HasMany
+    {
+        return $this->hasMany(BinomialEvaluation::class);
+    }
+}

--- a/app/Models/BinomialEvaluation.php
+++ b/app/Models/BinomialEvaluation.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\VRACore\VRACImage;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BinomialEvaluation extends Model
+{
+    protected $fillable = [
+        'image_id',
+        'user_id',
+        'binomial_id',
+        'value',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'image_id'    => 'string',
+            'user_id'     => 'string',
+            'binomial_id' => 'integer',
+            'value'       => 'integer',
+        ];
+    }
+
+    // ─── Relationships ────────────────────────────────────────────
+
+    public function image(): BelongsTo
+    {
+        return $this->belongsTo(VRACImage::class, 'image_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function binomial(): BelongsTo
+    {
+        return $this->belongsTo(Binomial::class);
+    }
+}

--- a/database/migrations/2026_05_25_000001_create_binomials_table.php
+++ b/database/migrations/2026_05_25_000001_create_binomials_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('binomials', function (Blueprint $table) {
+            $table->id();
+            $table->string('word_left');
+            $table->string('word_right');
+            $table->unsignedTinyInteger('order')->default(0);
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+
+        DB::table('binomials')->insert([
+            ['word_left' => 'Aberta',      'word_right' => 'Fechada',      'order' => 1, 'active' => true, 'created_at' => now(), 'updated_at' => now()],
+            ['word_left' => 'Interna',     'word_right' => 'Externa',      'order' => 2, 'active' => true, 'created_at' => now(), 'updated_at' => now()],
+            ['word_left' => 'Complexa',    'word_right' => 'Simples',      'order' => 3, 'active' => true, 'created_at' => now(), 'updated_at' => now()],
+            ['word_left' => 'Simétrica',   'word_right' => 'Assimétrica',  'order' => 4, 'active' => true, 'created_at' => now(), 'updated_at' => now()],
+            ['word_left' => 'Translúcida', 'word_right' => 'Opaca',        'order' => 5, 'active' => true, 'created_at' => now(), 'updated_at' => now()],
+            ['word_left' => 'Horizontal',  'word_right' => 'Vertical',     'order' => 6, 'active' => true, 'created_at' => now(), 'updated_at' => now()],
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('binomials');
+    }
+};

--- a/database/migrations/2026_05_25_000002_create_binomial_evaluations_table.php
+++ b/database/migrations/2026_05_25_000002_create_binomial_evaluations_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('binomial_evaluations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignUuid('image_id')->constrained('vrac_images')->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('binomial_id')->constrained('binomials')->cascadeOnDelete();
+            $table->unsignedTinyInteger('value'); // 0 - 100
+            $table->timestamps();
+
+            $table->unique(['image_id', 'user_id', 'binomial_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('binomial_evaluations');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AlbumController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\CommentLikeController;
+use App\Http\Controllers\BinomialEvaluationController;
 use App\Http\Controllers\ReportController;
 
 // álbumes
@@ -52,6 +53,11 @@ Route::apiResource('images', ImageController::class)->only(['index', 'show']);
 Route::apiResource('collectives', CollectiveController::class)->only(['index', 'show']);
 Route::get('actors', [ActorController::class, 'index']);
 Route::get('/images/{imageId}/comments', [CommentController::class, 'index']);
+
+// Binomials
+Route::get('/images/{image}/binomials', [BinomialEvaluationController::class, 'index']);
+Route::get('/images/{image}/binomials/report', [BinomialEvaluationController::class, 'report']);
+Route::get('/images/{image}/binomials/evaluations', [BinomialEvaluationController::class, 'evaluations']);
 Route::get('/comments/{commentId}/replies', [CommentController::class, 'replies']);
 
 // álbumes
@@ -98,6 +104,9 @@ Route::middleware('auth:api')->group(function () {
     Route::put('/albums/{album}/images', [AlbumController::class, 'syncImages']);
     Route::post('/albums/{album}/images', [AlbumController::class, 'addImage']);
     Route::delete('/albums/{album}/images', [AlbumController::class, 'removeImages']);
+
+    // Binomials
+    Route::post('/images/{image}/binomials', [BinomialEvaluationController::class, 'store']);
 
     // Reports
     Route::post('/reports', [ReportController::class, 'store']);


### PR DESCRIPTION
## Resumo
- Novas tabelas `binomials` e `binomial_evaluations` com migrations
- 4 endpoints para avaliação semântica de imagens
- Comando Artisan `binomials:import` para migrar dados legados via CSV

## Endpoints
- `GET /images/{image}/binomials` — médias gerais (tela principal)
- `POST /images/{image}/binomials` — enviar/atualizar avaliação (autenticado)
- `GET /images/{image}/binomials/report` — médias filtradas por data
- `GET /images/{image}/binomials/evaluations` — todas as avaliações individuais com médias

## Observações
- A importação de dados legados requer executar `php artisan binomials:import {arquivo}` manualmente no servidor
- Nenhuma tabela existente foi modificada